### PR TITLE
fixed Dockerfile image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:alpine
+FROM ruby:2-alpine
 RUN apk upgrade --no-cache \
     && apk add --no-cache --virtual build-dependencies build-base
 WORKDIR /usr/src/app


### PR DESCRIPTION
ruby:alpineのImageを使うとRuby3系が落ち下記エラーが出てコケる為、Ruby2系のImageを使うように変更しました。

```
 - Network docker-yaml_cv_default      Created                                                                     0.8s
 - Container docker-yaml_cv-make_cv-1  Created                                                                     0.2s
Attaching to docker-yaml_cv-make_cv-1
docker-yaml_cv-make_cv-1  | /usr/local/bundle/gems/prawn-2.4.0/lib/prawn/transformation_stack.rb:10:in `require': cannot load such file -- matrix (LoadError)
docker-yaml_cv-make_cv-1  |     from /usr/local/bundle/gems/prawn-2.4.0/lib/prawn/transformation_stack.rb:10:in `<top (required)>'
docker-yaml_cv-make_cv-1  |     from /usr/local/bundle/gems/prawn-2.4.0/lib/prawn.rb:67:in `require_relative'
docker-yaml_cv-make_cv-1  |     from /usr/local/bundle/gems/prawn-2.4.0/lib/prawn.rb:67:in `<top (required)>'
docker-yaml_cv-make_cv-1  |     from /usr/local/lib/ruby/3.1.0/bundler/runtime.rb:60:in `require'
docker-yaml_cv-make_cv-1  |     from /usr/local/lib/ruby/3.1.0/bundler/runtime.rb:60:in `block (2 levels) in require'
docker-yaml_cv-make_cv-1  |     from /usr/local/lib/ruby/3.1.0/bundler/runtime.rb:55:in `each'
docker-yaml_cv-make_cv-1  |     from /usr/local/lib/ruby/3.1.0/bundler/runtime.rb:55:in `block in require'
docker-yaml_cv-make_cv-1  |     from /usr/local/lib/ruby/3.1.0/bundler/runtime.rb:44:in `each'
docker-yaml_cv-make_cv-1  |     from /usr/local/lib/ruby/3.1.0/bundler/runtime.rb:44:in `require'
docker-yaml_cv-make_cv-1  |     from /usr/local/lib/ruby/3.1.0/bundler.rb:176:in `require'
docker-yaml_cv-make_cv-1  |     from make_cv.rb:4:in `<main>'
docker-yaml_cv-make_cv-1 exited with code 1
```