### PR TITLE
fix: avoid Bundler::GemNotFound error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,6 @@ RUN apk upgrade --no-cache \
     && apk add --no-cache --virtual build-dependencies build-base
 WORKDIR /usr/src/app
 COPY Gemfile /usr/src/app
-RUN bundle install
+RUN bundle config path vendor/bundle && \
+    bundle config set --local without 'documentation' && \
+    bundle install


### PR DESCRIPTION
手順に従って `docker compose up -d` にこぎつけたものの、エラーにより目的のpdfが生成できないことを発見したもので、これはその修正提案です。

上流である https://github.com/kaityo256/yaml_cv のリポジトリの内容を確認したところ、`bundle install` に関する説明記載について、 https://github.com/kaityo256/yaml_cv/commit/8e265f28e10e4a3ba963d44a4ce71eda32cc2e4e と https://github.com/kaityo256/yaml_cv/commit/91fdfb8e0ad0d54c33d481d80d7db12a94dbad7a のような変更が出ておりました。結果的には、これに追随するような `bundle install` の記載にしたところ、綺麗にエラーが解消して、pdfが出てくるようになりました。

当初は以下のようなエラーが出ていました。このエラーが出たあと、 `Dockerfile` を修正して、 `docker compose down --rmi all` してから再度 `up` すると、うまくいった感じです。よろしければ、マージいただければ幸いです。

```sh
$ docker compose up
[+] Building 1.6s (11/11) FINISHED                                                                                                                                                                                                                                                                                                                                                                                                                                                                     
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                                                                                                                                                                                                                              0.0s
 => => transferring dockerfile: 219B                                                                                                                                                                                                                                                                                                                                                                                                                                                              0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                                                                                                                                                                                                                 0.0s
 => => transferring context: 34B                                                                                                                                                                                                                                                                                                                                                                                                                                                                  0.0s
 => [internal] load metadata for docker.io/library/ruby:2-alpine                                                                                                                                                                                                                                                                                                                                                                                                                                  1.5s
 => [auth] library/ruby:pull token for registry-1.docker.io                                                                                                                                                                                                                                                                                                                                                                                                                                       0.0s
 => [1/5] FROM docker.io/library/ruby:2-alpine@sha256:371668748735a808d1fd1c506878e09f40cb542ffc758cfa7eb124f90827e8d9                                                                                                                                                                                                                                                                                                                                                                            0.0s
 => [internal] load build context                                                                                                                                                                                                                                                                                                                                                                                                                                                                 0.0s
 => => transferring context: 29B                                                                                                                                                                                                                                                                                                                                                                                                                                                                  0.0s
 => CACHED [2/5] RUN apk upgrade --no-cache     && apk add --no-cache --virtual build-dependencies build-base                                                                                                                                                                                                                                                                                                                                                                                     0.0s
 => CACHED [3/5] WORKDIR /usr/src/app                                                                                                                                                                                                                                                                                                                                                                                                                                                             0.0s
 => CACHED [4/5] COPY Gemfile /usr/src/app                                                                                                                                                                                                                                                                                                                                                                                                                                                        0.0s
 => CACHED [5/5] RUN bundle install                                                                                                                                                                                                                                                                                                                                                                                                                                                               0.0s
 => exporting to image                                                                                                                                                                                                                                                                                                                                                                                                                                                                            0.1s
 => => exporting layers                                                                                                                                                                                                                                                                                                                                                                                                                                                                           0.0s
 => => writing image sha256:d58ba02bb20fbe73c6c53cd2922f9effc8785f90b1113e73f9cf8bd582f5055d                                                                                                                                                                                                                                                                                                                                                                                                      0.0s
 => => naming to docker.io/library/docker-yaml_cv_make_cv                                                                                                                                                                                                                                                                                                                                                                                                                                         0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
[+] Running 2/2
 ⠿ Network docker-yaml_cv_default      Created                                                                                                                                                                                                                                                                                                                                                                                                                                                    0.0s
 ⠿ Container docker-yaml_cv-make_cv-1  Created                                                                                                                                                                                                                                                                                                                                                                                                                                                    0.1s
Attaching to docker-yaml_cv-make_cv-1
docker-yaml_cv-make_cv-1  | /usr/local/lib/ruby/2.7.0/bundler/spec_set.rb:86:in `block in materialize': Could not find matrix-0.4.2 in any of the sources (Bundler::GemNotFound)
docker-yaml_cv-make_cv-1  |     from /usr/local/lib/ruby/2.7.0/bundler/spec_set.rb:80:in `map!'
docker-yaml_cv-make_cv-1  |     from /usr/local/lib/ruby/2.7.0/bundler/spec_set.rb:80:in `materialize'
docker-yaml_cv-make_cv-1  |     from /usr/local/lib/ruby/2.7.0/bundler/definition.rb:170:in `specs'
docker-yaml_cv-make_cv-1  |     from /usr/local/lib/ruby/2.7.0/bundler/definition.rb:237:in `specs_for'
docker-yaml_cv-make_cv-1  |     from /usr/local/lib/ruby/2.7.0/bundler/definition.rb:226:in `requested_specs'
docker-yaml_cv-make_cv-1  |     from /usr/local/lib/ruby/2.7.0/bundler/runtime.rb:101:in `block in definition_method'
docker-yaml_cv-make_cv-1  |     from /usr/local/lib/ruby/2.7.0/bundler/runtime.rb:20:in `setup'
docker-yaml_cv-make_cv-1  |     from /usr/local/lib/ruby/2.7.0/bundler.rb:149:in `setup'
docker-yaml_cv-make_cv-1  |     from /usr/local/lib/ruby/2.7.0/bundler.rb:174:in `require'
docker-yaml_cv-make_cv-1  |     from make_cv.rb:4:in `<main>'
docker-yaml_cv-make_cv-1 exited with code 1
```